### PR TITLE
Add customisable hotkey for item spawner

### DIFF
--- a/SOTF_ModMenu/Main.cs
+++ b/SOTF_ModMenu/Main.cs
@@ -50,16 +50,7 @@ namespace SOTF_ModMenu
                 TextFieldAmount = GUI.TextField(new Rect(55, 252, 30, 20), TextFieldAmount);
                 if (GUI.Button(new Rect(88, 252, 70, 20), "Spawn"))
                 {
-                    try
-                    {
-                        int itemID = int.Parse(TextFieldItemID);
-                        int amount = int.Parse(TextFieldAmount);
-                        LocalPlayer.Inventory.AddItem(itemID, amount);
-                    }
-                    catch
-                    {
-                        Plugin.log.LogError("Failed to add item!");
-                    }
+                    SpawnItem();
                 }
                 GUI.Button(new Rect(12, 274, 146, 20), "Show All ID's (Soon!)");
             }
@@ -123,6 +114,28 @@ namespace SOTF_ModMenu
                         Cursor.visible = false;
                         Cursor.lockState = CursorLockMode.Locked;
                     }
+                }
+            }
+            
+            private void SpawnItemHotkeyPressed()
+            {
+                if (Input.GetKeyDown(Plugin.SpawnItemKeybind.Value))
+                {
+                    SpawnItem();
+                }
+            }
+            
+            private void SpawnItem()
+            {
+                try
+                {
+                    int itemID = int.Parse(TextFieldItemID);
+                    int amount = int.Parse(TextFieldAmount);
+                    LocalPlayer.Inventory.AddItem(itemID, amount);
+                }
+                catch
+                {
+                    Plugin.log.LogError("Failed to add item!");
                 }
             }
 

--- a/SOTF_ModMenu/Main.cs
+++ b/SOTF_ModMenu/Main.cs
@@ -58,6 +58,7 @@ namespace SOTF_ModMenu
             private void Update()
             {
                 ShowMenu();
+                SpawnItemHotkeyPressed();
 
                 if(vitals == null)
                 {

--- a/SOTF_ModMenu/Main.cs
+++ b/SOTF_ModMenu/Main.cs
@@ -57,8 +57,7 @@ namespace SOTF_ModMenu
 
             private void Update()
             {
-                ShowMenu();
-                SpawnItemHotkeyPressed();
+                RegisterHandlers();
 
                 if(vitals == null)
                 {
@@ -94,6 +93,12 @@ namespace SOTF_ModMenu
                 StructureCraftingSystem scs = LocalPlayer.StructureCraftingSystem;
                 scs.InstantBuild = Settings.InstantBuild;
 
+            }
+            
+            private void RegisterHandlers()
+            {
+                ShowMenu();
+                SpawnItemHotkeyPressed();
             }
             
             private void ShowMenu()

--- a/SOTF_ModMenu/Plugin.cs
+++ b/SOTF_ModMenu/Plugin.cs
@@ -18,10 +18,12 @@ namespace SOTF_ModMenu
             MODNAME = "SOTF_ModMenu",
             AUTHOR = "Nie",
             GUID = AUTHOR + "_" + MODNAME,
-            VERSION = "1.1.3";
+            VERSION = "1.1.4";
         
         public static ConfigFile ConfigFile = new (Path.Combine(Paths.ConfigPath, "SOTF_ModMenu.cfg"), true);
         public static ConfigEntry<KeyCode> ModMenuKeybind = ConfigFile.Bind("Hotkeys", "Toggle", KeyCode.BackQuote, "Enables or disables the Mod Menu");
+        public static ConfigEntry<KeyCode> SpawnItemKeybind = ConfigFile.Bind("Hotkeys", "SpawnItem", KeyCode.F8, "Spawns the currently stored item ID");
+
         public Plugin()
         {
             log = Log;


### PR DESCRIPTION
This is useful for when you're spawning logs etc. You can now just hit F8 (default) instead of opening the menu and double clicking the spawn button.

Creative mode builders should be happy about this one.